### PR TITLE
add a title attribute into the rss alternate link.

### DIFF
--- a/server/templates/public/layout.jade
+++ b/server/templates/public/layout.jade
@@ -4,7 +4,7 @@ html
     title Hacker News -> RSS
     link(href="/assets/stylesheets/main.css", rel='stylesheet', type='text/css')
     link(href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css", rel='stylesheet', type='text/css')
-    link(href="/rss", rel='alternate', type='application/rss+xml')
+    link(href="/rss", rel='alternate', type='application/rss+xml', title='RSS 2.0')
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
     script.
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Some browser (such as Safari) could not recognize the rss alternate link without title.

@shanzi Please review it. Thanks.
