### PR TITLE
fixed guid/comments link

### DIFF
--- a/server/controllers/public_controller.coffee
+++ b/server/controllers/public_controller.coffee
@@ -23,7 +23,7 @@ publicController.rss = (req, res) ->
     )
     record.feeds (feeds) =>
         for f in feeds
-            guid = "http://news.ycombinator.com/?item=#{f.id}"
+            guid = "http://news.ycombinator.com/item?id=#{f.id}"
             f.url = f.url.trim()
             f.url = "http://news.ycombinator.com/#{f.url}" if not f.url.match /^(\w+:)?\/\/.+/
             feed.addItem(


### PR DESCRIPTION
The link used currently doesn't work--it just goes to the HN front page. This is annoying in some readers (for example Tiny Tiny RSS) that make use of the link in the `<comments>` element.

Another option would be to leave the `guid` link as-is and just fix the `comments` link to prevent all older entries having their `guid` changed.
